### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,8 @@ on:
     types:
       - edited
       - published
+permissions:
+  contents: read
 env:
   DOCKER_IMAGE: ghcr.io/lgcorzo/llmops-python-package
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/lgcorzo/llmops-python-package/security/code-scanning/2](https://github.com/lgcorzo/llmops-python-package/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define minimal permissions for all jobs. Specifically, we will set `contents: read` as the default permission, which is sufficient for most workflows. Additionally, we will ensure that the `packages` job retains its specific `packages: write` permission, as it requires write access to GitHub Packages.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
