### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,6 @@
 name: Check
+permissions:
+  contents: read
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/lgcorzo/llmops-python-package/security/code-scanning/1](https://github.com/lgcorzo/llmops-python-package/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (root) to explicitly define the minimal permissions required. Since the workflow only appears to read repository contents, we will set `contents: read`. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
